### PR TITLE
fix: restructure BIP32 API for standard compatibility

### DIFF
--- a/ddk-ffi/src/ddk_ffi.udl
+++ b/ddk-ffi/src/ddk_ffi.udl
@@ -1,17 +1,31 @@
 namespace ddk_ffi {
     string version();
+
+    // === SEED OPERATIONS ===
     [Throws=DLCError]
     sequence<u8> convert_mnemonic_to_seed(string mnemonic, string? passphrase);
+
+    [Throws=DLCError]
+    sequence<u8> create_extkey_from_seed(sequence<u8> seed, string network);
+
+    // === EXTENDED KEY OPERATIONS ===
+    [Throws=DLCError]
+    sequence<u8> create_extkey_from_parent_path(sequence<u8> extkey, string network, string path);
+
+    [Throws=DLCError]
+    sequence<u8> get_pubkey_from_extkey(sequence<u8> extkey, string network);
+
+    [Throws=DLCError]
+    sequence<u8> get_xpub_from_xpriv(sequence<u8> xpriv, string network);
+
+    // === DEPRECATED ===
     [Throws=DLCError]
     sequence<u8> create_xpriv_from_parent_path(
-        sequence<u8> xpriv,
+        sequence<u8> seed_or_xpriv,
         string base_derivation_path,
         string network,
         string path
     );
-    [Throws=DLCError]
-    sequence<u8> get_xpub_from_xpriv(sequence<u8> xpriv, string network);
-
 
     // DLC Transaction Creation Functions
     [Throws=DLCError]


### PR DESCRIPTION
## What

- add new clean API functions:
  - create_extkey_from_seed: 64-byte seed → 78-byte master xpriv
  - create_extkey_from_parent_path: 78-byte xpriv → derived xpriv
  - get_pubkey_from_extkey: 78-byte extkey → 33-byte public key
- fix get_xpub_from_xpriv to only handle 78-byte encoded xprivs
- deprecate create_xpriv_from_parent_path (maintain backward compatibility)
- ensure 100% BIP39/BIP32 standard compliance

Resolves compatibility issues with CFD and bitcoinjs-lib

## Why

`get_xpub_from_xpriv` was broken, not compatible with bip32

```
pub fn get_xpub_from_xpriv(xpriv: Vec<u8>, network: String) -> Result<Vec<u8>, DLCError> {
    let xpriv = Xpriv::new_master(network, &xpriv)
        .map_err(|_| DLCError::KeyError(ExtendedKey::InvalidXpriv))?;
```

`let xpriv = Xpriv::new_master(network, &xpriv)` was wrong, because it called new_master on already derived extended privkeys (treating them as if they were 64 byte seeds). But 78 byte encoded extended privkey were being passed in, which was totally different than bip39 / bip32 compatibiltiy

one option, was to just modify `get_xpub_from_xpriv` to accept either 64 byte seed or 78 byte encoded extended privkey, but I figured better to refactor with better defined methods