### PR TITLE
fix: create cet adaptor points fn

### DIFF
--- a/ddk-ts/__test__/index.spec.ts
+++ b/ddk-ts/__test__/index.spec.ts
@@ -158,6 +158,27 @@ describe('creates and verifies adaptor signatures', () => {
 
     expect(adaptorSignatures.length).toBe(cets.length)
   })
+
+  test('creates adaptor points from oracle info', () => {
+    const { oracleInfo, messagesList } = getCets()
+
+    const result = ddk.createCetAdaptorPointsFromOracleInfo(oracleInfo, messagesList)
+
+    // Should return one adaptor point per CET
+    expect(Array.isArray(result)).toBe(true)
+    expect(result.length).toBe(messagesList.length) // 3 CETs = 3 adaptor points
+
+    // Each adaptor point should be a valid 33-byte compressed public key
+    result.forEach((adaptorPoint, index) => {
+      expect(Buffer.isBuffer(adaptorPoint)).toBe(true)
+      expect(adaptorPoint.length).toBe(33) // Compressed public key length
+      expect(adaptorPoint[0]).toBe(0x02) // Compressed public key prefix
+    })
+
+    // All adaptor points should be different
+    const uniquePoints = new Set(result.map((point) => point.toString('hex')))
+    expect(uniquePoints.size).toBe(result.length)
+  })
 })
 
 describe('DDK TypeScript Bindings', () => {
@@ -178,6 +199,7 @@ describe('DDK TypeScript Bindings', () => {
       'getRawFundingTransactionInputSignature',
       'signFundTransactionInput',
       'createCetAdaptorSignatureFromOracleInfo',
+      'createCetAdaptorPointsFromOracleInfo',
     ]
 
     requiredFunctions.forEach((funcName) => {


### PR DESCRIPTION
## Summary
This PR fixes the `createCetAdaptorPointsFromOracleInfo` function to correctly return multiple adaptor points (one per CET) instead of a single adaptor point.

## Problem
The function was incorrectly processing all CET messages together and returning only one adaptor point, when it should return one adaptor point per CET.

## Changes
- **Rust FFI Layer**: Fixed `create_cet_adaptor_points_from_oracle_info` to process each CET's messages separately
- **Message Processing**: Changed from flattening all messages to processing each CET individually
- **Return Value**: Now returns `Vec<Vec<u8>>` with one adaptor point per CET
- **Testing**: Added comprehensive test with proper assertions for:
  - Correct number of adaptor points returned (one per CET)
  - Valid 33-byte compressed public key format
  - Uniqueness of adaptor points
- **Export Validation**: Added function to required exports list

## Technical Details
- **Input**: Oracle info and 3D message structure `[CET][Outcome][Message]`
- **Processing**: Each CET's messages are processed individually using `dlc::get_adaptor_point_from_oracle_info`
- **Output**: Array of adaptor points, each being a 33-byte compressed public key
- **Error Handling**: Proper error propagation from DLC operations

## Testing
- [x] All existing tests pass
- [x] New function test passes with comprehensive assertions
- [x] Function correctly returns 3 adaptor points for 3 CETs
- [x] Each adaptor point is a valid compressed public key
- [x] All adaptor points are unique (as expected for different CETs)

## Usage
```typescript
const adaptorPoints = ddk.createCetAdaptorPointsFromOracleInfo(oracleInfo, messagesList)
// Returns: Array<Buffer> - one adaptor point per CET
```