### PR TITLE
feat: add create_cet_adaptor_sigs_from_points function

### DIFF
--- a/ddk-ffi/Cargo.toml
+++ b/ddk-ffi/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 uniffi = { version = "0.29.4", features = ["cli"] }
 # ddk-dlc = { path = "../../../ernest/dlcdevkit/dlc", features = ["use-serde"] }
 # ddk-dlc = { git = "https://github.com/bennyhodl/dlcdevkit.git", branch = "master", features = ["use-serde"] }
-ddk-dlc = { version = "1.0.4", features = ["use-serde"] }
+ddk-dlc = { version = "1.0.9", features = ["use-serde"] }
 bitcoin = "0.32.7"
 thiserror = "2.0.12"
 secp256k1-zkp = "0.11.0"

--- a/ddk-ffi/src/ddk_ffi.udl
+++ b/ddk-ffi/src/ddk_ffi.udl
@@ -150,6 +150,15 @@ namespace ddk_ffi {
         sequence<sequence<sequence<sequence<u8>>>> msgs
     );
 
+    [Throws=DLCError]
+    sequence<AdaptorSignature> create_cet_adaptor_sigs_from_points(
+        sequence<Transaction> cets,
+        sequence<sequence<u8>> adaptor_points,
+        sequence<u8> funding_secret_key,
+        sequence<u8> funding_script_pubkey,
+        u64 fund_output_value
+    );
+
     boolean verify_cet_adaptor_sigs_from_oracle_info(
         sequence<AdaptorSignature> adaptor_sigs,
         sequence<Transaction> cets,

--- a/ddk-ffi/src/lib.rs
+++ b/ddk-ffi/src/lib.rs
@@ -957,6 +957,64 @@ pub fn create_cet_adaptor_sigs_from_oracle_info(
     Ok(adaptor_sigs)
 }
 
+/// Create adaptor signatures from pre-computed adaptor points.
+/// This matches Fordefi's interface where adaptor points are provided directly.
+pub fn create_cet_adaptor_sigs_from_points(
+    cets: Vec<Transaction>,
+    adaptor_points: Vec<Vec<u8>>,
+    funding_secret_key: Vec<u8>,
+    funding_script_pubkey: Vec<u8>,
+    fund_output_value: u64,
+) -> Result<Vec<AdaptorSignature>, DLCError> {
+    if cets.len() != adaptor_points.len() {
+        return Err(DLCError::InvalidArgument(format!(
+            "CETs length ({}) does not match adaptor points length ({})",
+            cets.len(),
+            adaptor_points.len()
+        )));
+    }
+
+    let cets = cets
+        .iter()
+        .map(transaction_to_btc_tx)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let adaptor_points = adaptor_points
+        .iter()
+        .map(|p| {
+            PublicKey::from_slice(p)
+                .map_err(|_| DLCError::InvalidArgument("Invalid adaptor point".to_string()))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let funding_sk = SecretKey::from_slice(&funding_secret_key)
+        .map_err(|_| DLCError::InvalidArgument("Invalid funding secret key".to_string()))?;
+    let funding_script = Script::from_bytes(&funding_script_pubkey);
+
+    let inputs: Vec<(&bitcoin::Transaction, &PublicKey)> =
+        cets.iter().zip(adaptor_points.iter()).collect();
+
+    let secp = get_secp_context();
+    let adaptor_sigs = ddk_dlc::create_cet_adaptor_sigs_from_points(
+        secp,
+        &inputs,
+        &funding_sk,
+        funding_script,
+        Amount::from_sat(fund_output_value),
+    )
+    .map_err(|e| DLCError::Secp256k1Error(e.to_string()))?;
+
+    let adaptor_sigs = adaptor_sigs
+        .iter()
+        .map(|sig| AdaptorSignature {
+            signature: sig.as_ref().to_vec(),
+            proof: Vec::new(),
+        })
+        .collect::<Vec<_>>();
+
+    Ok(adaptor_sigs)
+}
+
 pub fn verify_cet_adaptor_sig_from_oracle_info(
     adaptor_sig: AdaptorSignature,
     cet: Transaction,

--- a/ddk-ffi/src/lib.rs
+++ b/ddk-ffi/src/lib.rs
@@ -958,7 +958,6 @@ pub fn create_cet_adaptor_sigs_from_oracle_info(
 }
 
 /// Create adaptor signatures from pre-computed adaptor points.
-/// This matches Fordefi's interface where adaptor points are provided directly.
 pub fn create_cet_adaptor_sigs_from_points(
     cets: Vec<Transaction>,
     adaptor_points: Vec<Vec<u8>>,

--- a/ddk-ts/src/lib.rs
+++ b/ddk-ts/src/lib.rs
@@ -468,6 +468,36 @@ pub fn create_cet_adaptor_sigs_from_oracle_info(
 }
 
 #[napi]
+pub fn create_cet_adaptor_sigs_from_points(
+  cets: Vec<Transaction>,
+  adaptor_points: Vec<Buffer>,
+  funding_secret_key: Buffer,
+  funding_script_pubkey: Buffer,
+  fund_output_value: BigInt,
+) -> Result<Vec<AdaptorSignature>> {
+  let ffi_adaptor_points: Vec<Vec<u8>> = adaptor_points.iter().map(buffer_to_vec).collect();
+
+  let sigs = ddk_ffi::create_cet_adaptor_sigs_from_points(
+    cets
+      .into_iter()
+      .map(|cet| cet.try_into())
+      .collect::<Result<Vec<_>, _>>()?,
+    ffi_adaptor_points,
+    buffer_to_vec(&funding_secret_key),
+    buffer_to_vec(&funding_script_pubkey),
+    bigint_to_u64(&fund_output_value)?,
+  )
+  .map_err(|e| Error::from_reason(format!("{:?}", e)))?;
+
+  let result = sigs
+    .into_iter()
+    .map(|sig| sig.into())
+    .collect::<Vec<AdaptorSignature>>();
+
+  Ok(result)
+}
+
+#[napi]
 pub fn create_cet_adaptor_signature_from_oracle_info(
   cet: Transaction,
   oracle_info: OracleInfo,


### PR DESCRIPTION
## Summary
Adds `create_cet_adaptor_sigs_from_points` to ddk-ffi, matching Fordefi's interface where adaptor points are provided directly instead of being computed from oracle info.

## Changes
- Add `create_cet_adaptor_sigs_from_points` to ddk-ffi/src/lib.rs (core Rust implementation)
- Add function declaration to ddk-ffi/src/ddk_ffi.udl (UniFFI interface)
- Add napi binding to ddk-ts/src/lib.rs (Node.js/TypeScript support)