### PR TITLE
feat: add contract_flags param to DLC transaction creation

### DIFF
--- a/ddk-ffi/Cargo.lock
+++ b/ddk-ffi/Cargo.lock
@@ -267,8 +267,9 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "ddk-dlc"
-version = "1.0.11"
-source = "git+https://github.com/bennyhodl/dlcdevkit.git?branch=master#67f8d7ab5eb2dbcf6ea6fe3fa13c4bbe7b614d34"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84a9a9946895deaf49097d808bdafbaf9998323f20691aa4227161c13b32bc2"
 dependencies = [
  "bitcoin",
  "miniscript",

--- a/ddk-ffi/Cargo.lock
+++ b/ddk-ffi/Cargo.lock
@@ -267,9 +267,8 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "ddk-dlc"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2730518f3d2166431d2cfb5c9a158063b68d49b875a115468b150e175f76b80"
+version = "1.0.11"
+source = "git+https://github.com/bennyhodl/dlcdevkit.git?branch=master#67f8d7ab5eb2dbcf6ea6fe3fa13c4bbe7b614d34"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -280,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "ddk_ffi"
-version = "0.3.35"
+version = "0.3.38"
 dependencies = [
  "bip39",
  "bitcoin",

--- a/ddk-ffi/Cargo.toml
+++ b/ddk-ffi/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 [dependencies]
 uniffi = { version = "0.29.4", features = ["cli"] }
 # ddk-dlc = { path = "../../../ernest/dlcdevkit/dlc", features = ["use-serde"] }
-# ddk-dlc = { version = "1.0.9", features = ["use-serde"] }
-ddk-dlc = { git = "https://github.com/bennyhodl/dlcdevkit.git", branch = "master", features = ["use-serde"] }
+# ddk-dlc = { git = "https://github.com/bennyhodl/dlcdevkit.git", branch = "master", features = ["use-serde"] }
+ddk-dlc = { version = "1.1.0", features = ["use-serde"] }
 bitcoin = "0.32.7"
 thiserror = "2.0.12"
 secp256k1-zkp = "0.11.0"

--- a/ddk-ffi/Cargo.toml
+++ b/ddk-ffi/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 [dependencies]
 uniffi = { version = "0.29.4", features = ["cli"] }
 # ddk-dlc = { path = "../../../ernest/dlcdevkit/dlc", features = ["use-serde"] }
-# ddk-dlc = { git = "https://github.com/bennyhodl/dlcdevkit.git", branch = "master", features = ["use-serde"] }
-ddk-dlc = { version = "1.0.9", features = ["use-serde"] }
+# ddk-dlc = { version = "1.0.9", features = ["use-serde"] }
+ddk-dlc = { git = "https://github.com/bennyhodl/dlcdevkit.git", branch = "master", features = ["use-serde"] }
 bitcoin = "0.32.7"
 thiserror = "2.0.12"
 secp256k1-zkp = "0.11.0"

--- a/ddk-ffi/src/ddk_ffi.udl
+++ b/ddk-ffi/src/ddk_ffi.udl
@@ -43,9 +43,10 @@ namespace ddk_ffi {
         u64 fee_rate,
         u32 fund_lock_time,
         u32 cet_lock_time,
-        u64 fund_output_serial_id
+        u64 fund_output_serial_id,
+        u8 contract_flags
     );
-    
+
     [Throws=DLCError]
     DlcTransactions create_spliced_dlc_transactions(
         sequence<Payout> outcomes,
@@ -55,7 +56,8 @@ namespace ddk_ffi {
         u64 fee_rate,
         u32 fund_lock_time,
         u32 cet_lock_time,
-        u64 fund_output_serial_id
+        u64 fund_output_serial_id,
+        u8 contract_flags
     );
     
     [Throws=DLCError]

--- a/ddk-ffi/src/lib.rs
+++ b/ddk-ffi/src/lib.rs
@@ -385,6 +385,7 @@ pub fn create_dlc_transactions(
     fund_lock_time: u32,
     cet_lock_time: u32,
     fund_output_serial_id: u64,
+    contract_flags: u8,
 ) -> Result<DlcTransactions, DLCError> {
     // Convert UniFFI types to rust-dlc types
     let rust_local_params = party_params_to_rust(&local_params)?;
@@ -409,6 +410,7 @@ pub fn create_dlc_transactions(
         fund_lock_time,
         cet_lock_time,
         fund_output_serial_id,
+        contract_flags,
     )
     .map_err(DLCError::from)?;
 
@@ -426,6 +428,7 @@ pub fn create_spliced_dlc_transactions(
     fund_lock_time: u32,
     cet_lock_time: u32,
     fund_output_serial_id: u64,
+    contract_flags: u8,
 ) -> Result<DlcTransactions, DLCError> {
     // Convert UniFFI types to rust-dlc types
     let rust_local_params = party_params_to_rust(&local_params)?;
@@ -450,6 +453,7 @@ pub fn create_spliced_dlc_transactions(
         fund_lock_time,
         cet_lock_time,
         fund_output_serial_id,
+        contract_flags,
     )
     .map_err(DLCError::from)?;
 
@@ -1665,6 +1669,7 @@ mod tests {
             10,  // fund lock time
             10,  // cet lock time
             0,   // fund output serial id
+            0,   // contract flags
         );
 
         assert!(result.is_ok());
@@ -1993,6 +1998,7 @@ mod tests {
             10,
             10,
             0,
+            0,
         )
         .unwrap();
 
@@ -2151,7 +2157,8 @@ mod tests {
             4,
             10,
             10,
-            0, // Add missing fund_output_serial_id parameter
+            0,
+            0,
         )
         .unwrap();
 
@@ -2276,6 +2283,7 @@ mod tests {
             10,
             10,
             0,
+            0,
         )
         .unwrap();
 
@@ -2333,6 +2341,7 @@ mod tests {
             4,
             10,
             10,
+            0,
             0,
         )
         .unwrap();
@@ -2465,6 +2474,7 @@ mod tests {
             4,
             10,
             10,
+            0,
             0,
         )
         .unwrap();

--- a/ddk-ts/Cargo.toml
+++ b/ddk-ts/Cargo.toml
@@ -19,8 +19,8 @@ napi-derive = "3.0.0"
 
 # Match the same dependencies as ddk-ffi
 # ddk-dlc = { path = "../../../ernest/dlcdevkit/dlc", features = ["use-serde"] }
-# ddk-dlc = { git = "https://github.com/bennyhodl/dlcdevkit.git", branch = "master", features = ["use-serde"] }
-ddk-dlc = { version = "1.0.4", features = ["use-serde"] }
+# ddk-dlc = { version = "1.0.4", features = ["use-serde"] }
+ddk-dlc = { git = "https://github.com/bennyhodl/dlcdevkit.git", branch = "master", features = ["use-serde"] }
 bitcoin = "0.32.7"
 thiserror = "2.0.12"
 secp256k1-zkp = "0.11.0"

--- a/ddk-ts/Cargo.toml
+++ b/ddk-ts/Cargo.toml
@@ -20,7 +20,7 @@ napi-derive = "3.0.0"
 # Match the same dependencies as ddk-ffi
 # ddk-dlc = { path = "../../../ernest/dlcdevkit/dlc", features = ["use-serde"] }
 # ddk-dlc = { version = "1.0.4", features = ["use-serde"] }
-ddk-dlc = { git = "https://github.com/bennyhodl/dlcdevkit.git", branch = "master", features = ["use-serde"] }
+ddk-dlc = { version = "1.1.0", features = ["use-serde"] }
 bitcoin = "0.32.7"
 thiserror = "2.0.12"
 secp256k1-zkp = "0.11.0"

--- a/ddk-ts/src/lib.rs
+++ b/ddk-ts/src/lib.rs
@@ -49,23 +49,13 @@ pub fn create_dlc_transactions(
   fund_lock_time: u32,
   cet_lock_time: u32,
   fund_output_serial_id: BigInt,
+  contract_flags: u8,
 ) -> Result<DlcTransactions> {
-  // log_to_console(env, "create_dlc_transactions: parsing inputs")
-  //   .map_err(|e| Error::from_reason(format!("{:?}", e)))?;
-
   let ffi_outcomes: Result<Vec<ddk_ffi::Payout>> =
     outcomes.into_iter().map(TryInto::try_into).collect();
 
   let ffi_local_params = local_params.try_into()?;
   let ffi_remote_params = remote_params.try_into()?;
-  // log_to_console(env, "create_dlc_transactions: inputs parsed correctly")
-  //   .map_err(|e| Error::from_reason(format!("{:?}", e)))?;
-
-  // log_to_console(
-  //   env,
-  //   "create_dlc_transactions: calling ddk_ffi::create_dlc_transactions with inputs",
-  // )
-  // .map_err(|e| Error::from_reason(format!("{:?}", e)))?;
 
   let result = ddk_ffi::create_dlc_transactions(
     ffi_outcomes?,
@@ -76,14 +66,9 @@ pub fn create_dlc_transactions(
     fund_lock_time,
     cet_lock_time,
     bigint_to_u64(&fund_output_serial_id)?,
+    contract_flags,
   )
-  .map_err(|e| {
-    // let _ = log_to_console(
-    //   env,
-    //   &format!("ddk_ffi::create_dlc_transactions: error: {:?}", e),
-    // );
-    Error::from_reason(format!("{:?}", e))
-  })?;
+  .map_err(|e| Error::from_reason(format!("{:?}", e)))?;
 
   Ok(result.into())
 }
@@ -98,6 +83,7 @@ pub fn create_spliced_dlc_transactions(
   fund_lock_time: u32,
   cet_lock_time: u32,
   fund_output_serial_id: BigInt,
+  contract_flags: u8,
 ) -> Result<DlcTransactions> {
   let ffi_outcomes: Result<Vec<ddk_ffi::Payout>> =
     outcomes.into_iter().map(TryInto::try_into).collect();
@@ -114,6 +100,7 @@ pub fn create_spliced_dlc_transactions(
     fund_lock_time,
     cet_lock_time,
     bigint_to_u64(&fund_output_serial_id)?,
+    contract_flags,
   )
   .map_err(|e| Error::from_reason(format!("{:?}", e)))?;
 


### PR DESCRIPTION
## Summary
Adds a `contract_flags` parameter (u8) to `create_dlc_transactions` and `create_spliced_dlc_transactions` across ddk-ffi and ddk-ts,

## Changes
- Added `contract_flags: u8` parameter to `create_dlc_transactions` and `create_spliced_dlc_transactions` in ddk-ffi Rust, UDL, and ddk-ts
- Switched `ddk-dlc` dependency from crates.io to git master branch in both ddk-ffi and ddk-ts (picks up upstream contract_flags support)
- Updated all tests to pass the new parameter support)
- Updated all tests to pass the new parameter
- Cleaned up commented-out logging code in ddk-ts