### PR TITLE
chore: bump ddk-dlc to 1.1.1

### DIFF
--- a/ddk-ffi/Cargo.lock
+++ b/ddk-ffi/Cargo.lock
@@ -267,9 +267,9 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "ddk-dlc"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84a9a9946895deaf49097d808bdafbaf9998323f20691aa4227161c13b32bc2"
+checksum = "a22a90817914165f52e5f3a38841faa020700c719eb40baca8bab5318458b812"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "ddk_ffi"
-version = "0.3.39"
+version = "0.3.40"
 dependencies = [
  "bip39",
  "bitcoin",

--- a/ddk-ffi/Cargo.toml
+++ b/ddk-ffi/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 uniffi = { version = "0.29.4", features = ["cli"] }
 # ddk-dlc = { path = "../../../ernest/dlcdevkit/dlc", features = ["use-serde"] }
 # ddk-dlc = { git = "https://github.com/bennyhodl/dlcdevkit.git", branch = "master", features = ["use-serde"] }
-ddk-dlc = { version = "1.1.0", features = ["use-serde"] }
+ddk-dlc = { version = "1.1.1", features = ["use-serde"] }
 bitcoin = "0.32.7"
 thiserror = "2.0.12"
 secp256k1-zkp = "0.11.0"

--- a/ddk-ts/Cargo.toml
+++ b/ddk-ts/Cargo.toml
@@ -20,7 +20,7 @@ napi-derive = "3.0.0"
 # Match the same dependencies as ddk-ffi
 # ddk-dlc = { path = "../../../ernest/dlcdevkit/dlc", features = ["use-serde"] }
 # ddk-dlc = { version = "1.0.4", features = ["use-serde"] }
-ddk-dlc = { version = "1.1.0", features = ["use-serde"] }
+ddk-dlc = { version = "1.1.1", features = ["use-serde"] }
 bitcoin = "0.32.7"
 thiserror = "2.0.12"
 secp256k1-zkp = "0.11.0"


### PR DESCRIPTION
## Summary

Bumps `ddk-dlc` from 1.1.0 to 1.1.1 in both `ddk-ffi` and `ddk-ts` crates.

## Changes

- `ddk-ffi/Cargo.toml`: ddk-dlc 1.1.0 → 1.1.1
- `ddk-ts/Cargo.toml`: ddk-dlc 1.1.0 → 1.1.1
- `ddk-ffi/Cargo.lock`: updated