### PR TITLE
Add wasm32-wasip1-threads build target for browser support

### DIFF
--- a/.github/workflows/ddk-ts.yml
+++ b/.github/workflows/ddk-ts.yml
@@ -127,10 +127,73 @@ jobs:
           fi
           echo "✅ Linux x64 build successful"
 
+  build-wasm:
+    name: Build WASM (wasm32-wasip1-threads)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1-threads
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Setup WASI SDK
+        run: |
+          curl -sL -o /tmp/wasi-sdk.tar.gz \
+            https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-linux.tar.gz
+          sudo mkdir -p /opt/wasi-sdk
+          sudo tar xzf /tmp/wasi-sdk.tar.gz -C /opt/wasi-sdk --strip-components=1
+          echo "WASI_SDK_PATH=/opt/wasi-sdk" >> "$GITHUB_ENV"
+
+      - name: Cache cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ddk-ts/target
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache pnpm store
+        uses: actions/cache@v3
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Install Dependencies
+        run: |
+          cd ddk-ts
+          pnpm install --no-frozen-lockfile
+
+      - name: Build for WASM
+        run: |
+          cd ddk-ts
+          pnpm build:wasm
+
+      - name: Verify Build Output
+        run: |
+          if [ ! -f "ddk-ts/dist/ddk-ts.wasm32-wasi.wasm" ]; then
+            echo "Error: ddk-ts.wasm32-wasi.wasm not generated"
+            exit 1
+          fi
+          echo "✅ WASM build successful"
+
   test-typescript:
     name: Test TypeScript Package
     runs-on: ubuntu-latest
-    needs: [build-darwin-arm64, build-linux-x64]
+    needs: [build-darwin-arm64, build-linux-x64, build-wasm]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,10 +55,18 @@ jobs:
             target: aarch64-apple-darwin
             short: darwin-arm64
             build: pnpm build:darwin-arm64
+            artifact_path: ddk-ts/dist/ddk-ts.*.node
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             short: linux-x64-gnu
             build: pnpm build:linux-x64
+            artifact_path: ddk-ts/dist/ddk-ts.*.node
+          - host: ubuntu-latest
+            target: wasm32-wasip1-threads
+            short: wasm32-wasi
+            build: pnpm build:wasm
+            wasi: true
+            artifact_path: ddk-ts/dist/ddk-ts.wasm32-wasi.wasm
     runs-on: ${{ matrix.host }}
     steps:
       - uses: actions/checkout@v4
@@ -71,6 +79,14 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           version: 8
+      - name: Setup WASI SDK
+        if: matrix.wasi
+        run: |
+          curl -sL -o /tmp/wasi-sdk.tar.gz \
+            https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-linux.tar.gz
+          sudo mkdir -p /opt/wasi-sdk
+          sudo tar xzf /tmp/wasi-sdk.tar.gz -C /opt/wasi-sdk --strip-components=1
+          echo "WASI_SDK_PATH=/opt/wasi-sdk" >> "$GITHUB_ENV"
       - name: Install dependencies
         run: cd ddk-ts && pnpm install --no-frozen-lockfile
       - name: Build
@@ -79,7 +95,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ddk-ts-bindings-${{ matrix.target }}
-          path: ddk-ts/dist/${{ env.APP_NAME }}.*.node
+          path: ${{ matrix.artifact_path }}
           if-no-files-found: error
 
   test-ddk-ts:
@@ -162,8 +178,11 @@ jobs:
           pattern: ddk-ts-bindings-*
       - name: Create sub-package directories
         run: cd ddk-ts && npx napi create-npm-dirs
+      # --build-output-dir dist: the wasm32-wasi sibling's JS glue (*.wasi.cjs,
+      # *.wasi-browser.js, wasi-worker*.mjs) is emitted into dist/ by the build
+      # above; the .wasm/.node binaries come from the downloaded artifacts.
       - name: Move binaries into sub-package directories
-        run: cd ddk-ts && npx napi artifacts
+        run: cd ddk-ts && npx napi artifacts --build-output-dir dist
       # Main package must not ship .node binaries; each sibling package carries its own.
       - name: Strip binaries from main package dist/
         run: rm -f ddk-ts/dist/*.node

--- a/ddk-ffi/Cargo.toml
+++ b/ddk-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ddk_ffi"
-version = "0.3.42"
+version = "0.3.43"
 edition = "2021"
 license = "MIT"
 description = "rust-dlc language bindings"

--- a/ddk-rn/package.json
+++ b/ddk-rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bennyblader/ddk-rn",
-  "version": "0.3.42",
+  "version": "0.3.43",
   "description": "dlcdevkit bindings for react-native",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/ddk-ts/CHANGELOG.md
+++ b/ddk-ts/CHANGELOG.md
@@ -1,8 +1,9 @@
 # DDK-TS Changelog
 
-## [Unreleased]
+## [0.3.43] - 2026-07-21
 - Added `wasm32-wasip1-threads` build target for browser/WASM support (`pnpm build:wasm`)
 - Wired the WASM target into CI and the release/publish pipeline (builds the `@bennyblader/ddk-ts-wasm32-wasi` sibling package)
+- Added `browser` field so bundlers resolve the WASM binding, plus a Vite browser example (`example-browser/`)
 
 ## [0.1.11] - 2025-01-15
 - Updated package configuration

--- a/ddk-ts/CHANGELOG.md
+++ b/ddk-ts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # DDK-TS Changelog
 
+## [Unreleased]
+- Added `wasm32-wasip1-threads` build target for browser/WASM support (`pnpm build:wasm`)
+- Wired the WASM target into CI and the release/publish pipeline (builds the `@bennyblader/ddk-ts-wasm32-wasi` sibling package)
+
 ## [0.1.11] - 2025-01-15
 - Updated package configuration
 

--- a/ddk-ts/Cargo.toml
+++ b/ddk-ts/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 ddk_ffi = { path = "../ddk-ffi" }
 
 # NAPI-RS dependencies
-napi = { version = "3.0.0", default-features = false, features = ["napi8", "async", "serde-json"] }
+napi = { version = "3.0.0", default-features = false, features = ["napi8", "serde-json"] }
 napi-derive = "3.0.0"
 
 # Match the same dependencies as ddk-ffi

--- a/ddk-ts/Cargo.toml
+++ b/ddk-ts/Cargo.toml
@@ -3,7 +3,7 @@
 authors = ["benny b <ben@bitcoinbay.foundation>"]
 edition = "2021"
 name = "ddk_ts"
-version = "0.3.42"
+version = "0.3.43"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/ddk-ts/example-browser/.gitignore
+++ b/ddk-ts/example-browser/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+*.log

--- a/ddk-ts/example-browser/README.md
+++ b/ddk-ts/example-browser/README.md
@@ -26,8 +26,8 @@ pnpm build && pnpm preview
 Open the page — you should see:
 
 ```
-ddk-ts version: 0.3.42
-✅ WASM loaded. ddk-ts version() -> 0.3.42
+ddk-ts version: 0.3.43
+✅ WASM loaded. ddk-ts version() -> 0.3.43
    crossOriginIsolated: true
 ```
 

--- a/ddk-ts/example-browser/README.md
+++ b/ddk-ts/example-browser/README.md
@@ -1,0 +1,72 @@
+# ddk-ts browser example
+
+A minimal [Vite](https://vitejs.dev/) app that loads the **WASM** build of
+`@bennyblader/ddk-ts` in the browser and prints `version()` to prove the binding
+instantiated. If you see a version number, the WASM binding works in a browser.
+
+## Run it
+
+The example uses the WASM binary built into `../dist`, so build that first:
+
+```bash
+# from ddk-ts/  (one level up) — needs the WASI SDK, see ../README
+export WASI_SDK_PATH=/path/to/wasi-sdk
+pnpm build:wasm
+```
+
+Then, from this folder:
+
+```bash
+pnpm install
+pnpm dev        # http://localhost:5173
+# or:
+pnpm build && pnpm preview
+```
+
+Open the page — you should see:
+
+```
+ddk-ts version: 0.3.42
+✅ WASM loaded. ddk-ts version() -> 0.3.42
+   crossOriginIsolated: true
+```
+
+## How a real consumer uses this
+
+In an app that installs the published package, the code is just:
+
+```ts
+import { version } from '@bennyblader/ddk-ts'
+console.log(version())
+```
+
+The bundler follows the package's `browser` field to `dist/browser.js`, which
+re-exports `@bennyblader/ddk-ts-wasm32-wasi` (the WASM sibling package). Two
+things a consumer must set up:
+
+1. **Install the WASM sibling.** It's published with `cpu: ["wasm32"]`, so npm
+   skips it on normal machines. Force it in:
+   - **pnpm:** add to your app's `package.json`:
+     ```json
+     "pnpm": { "supportedArchitectures": { "cpu": ["wasm32"] } }
+     ```
+   - **npm:** `npm install @bennyblader/ddk-ts-wasm32-wasi --force`
+   - **yarn:** `supportedArchitectures: cpu: ["wasm32"]` in `.yarnrc.yml`
+
+2. **Cross-origin isolation.** The target is `wasm32-wasip1-threads`, which uses
+   threads + `SharedArrayBuffer`. The page must be served with:
+   ```
+   Cross-Origin-Opener-Policy: same-origin
+   Cross-Origin-Embedder-Policy: require-corp
+   ```
+   Without these, `SharedArrayBuffer` is unavailable and instantiation fails.
+
+## Why this example aliases the package
+
+`@bennyblader/ddk-ts-wasm32-wasi` is generated at publish time and isn't on npm
+yet, so this example can't install it the normal way. Instead, `vite.config.ts`
+aliases `@bennyblader/ddk-ts` straight to the built `../dist/ddk-ts.wasi-browser.js`.
+That's a **local-dev shortcut only** — a published consumer never needs the
+alias, just the two steps above. The config also sets the COOP/COEP headers (for
+both `dev` and `preview`) and `build.target: "esnext"` (the binding instantiates
+via top-level `await`).

--- a/ddk-ts/example-browser/index.html
+++ b/ddk-ts/example-browser/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ddk-ts — browser (WASM)</title>
+    <style>
+      body {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        max-width: 40rem;
+        margin: 4rem auto;
+        padding: 0 1rem;
+        line-height: 1.5;
+      }
+      #version {
+        font-size: 1.5rem;
+        font-weight: 700;
+      }
+      .ok { color: #16a34a; }
+      .err { color: #dc2626; }
+      pre { background: #f4f4f5; padding: 0.75rem; border-radius: 6px; overflow-x: auto; }
+    </style>
+  </head>
+  <body>
+    <h1>@bennyblader/ddk-ts</h1>
+    <p>Rust DLC bindings running as WebAssembly in the browser.</p>
+    <p>ddk-ts version: <span id="version">loading…</span></p>
+    <pre id="log"></pre>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/ddk-ts/example-browser/package.json
+++ b/ddk-ts/example-browser/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ddk-ts-browser-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Minimal Vite browser example that loads the ddk-ts WASM binding and prints version()",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4173"
+  },
+  "dependencies": {
+    "@bennyblader/ddk-ts": "workspace:*"
+  },
+  "devDependencies": {
+    "@napi-rs/wasm-runtime": "^1.1.6",
+    "vite": "^5.4.0"
+  }
+}

--- a/ddk-ts/example-browser/src/main.ts
+++ b/ddk-ts/example-browser/src/main.ts
@@ -1,0 +1,24 @@
+// In a real app this is all you write. The bundler resolves
+// `@bennyblader/ddk-ts` to its `browser` entry, which loads the WASM binding.
+// (Locally we alias it in vite.config.ts — see README.md.)
+import { version } from '@bennyblader/ddk-ts'
+
+const versionEl = document.getElementById('version') as HTMLSpanElement
+const logEl = document.getElementById('log') as HTMLPreElement
+
+const log = (msg: string) => {
+  logEl.textContent += msg + '\n'
+  console.log(msg)
+}
+
+try {
+  const v = version()
+  versionEl.textContent = v
+  versionEl.className = 'ok'
+  log(`✅ WASM loaded. ddk-ts version() -> ${v}`)
+  log(`   crossOriginIsolated: ${globalThis.crossOriginIsolated}`)
+} catch (err) {
+  versionEl.textContent = 'failed'
+  versionEl.className = 'err'
+  log(`❌ ${err instanceof Error ? err.stack ?? err.message : String(err)}`)
+}

--- a/ddk-ts/example-browser/src/vite-env.d.ts
+++ b/ddk-ts/example-browser/src/vite-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+// The package name is aliased to the built WASM browser binding, which ships no
+// .d.ts. Declare the one export this example uses so tsc/editors stay quiet.
+declare module '@bennyblader/ddk-ts' {
+  export function version(): string
+}

--- a/ddk-ts/example-browser/tsconfig.json
+++ b/ddk-ts/example-browser/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/ddk-ts/example-browser/vite.config.ts
+++ b/ddk-ts/example-browser/vite.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig } from 'vite'
+import { resolve } from 'node:path'
+
+// The ddk-ts package root (one level up), where the built dist/ lives.
+const ddkTsRoot = resolve(__dirname, '..')
+
+// wasm32-wasip1-threads uses threads (SharedArrayBuffer), so the page MUST be
+// cross-origin isolated. These headers make the browser grant SAB.
+const crossOriginIsolation = {
+  'Cross-Origin-Opener-Policy': 'same-origin',
+  'Cross-Origin-Embedder-Policy': 'require-corp',
+}
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      // LOCAL DEV SHORTCUT: point the package name straight at the built WASM
+      // browser binding in ../dist. A published consumer never needs this — the
+      // package's `browser` field forwards `@bennyblader/ddk-ts` to the
+      // `@bennyblader/ddk-ts-wasm32-wasi` sibling automatically. We alias here
+      // only because that sibling is generated at publish time and isn't on npm
+      // yet. See README.md.
+      '@bennyblader/ddk-ts': resolve(ddkTsRoot, 'dist/ddk-ts.wasi-browser.js'),
+    },
+  },
+  optimizeDeps: {
+    // The WASM binding pulls a Worker + .wasm via import.meta.url; esbuild
+    // pre-bundling mangles those URLs, so keep it out of the optimizer.
+    exclude: ['@bennyblader/ddk-ts', '@napi-rs/wasm-runtime'],
+  },
+  // The WASM binding instantiates via top-level await, so target a runtime
+  // that supports it.
+  build: { target: 'esnext' },
+  server: {
+    // Allow Vite to serve ../dist/*.wasm and the worker file (outside this dir).
+    fs: { allow: [ddkTsRoot, __dirname] },
+    headers: crossOriginIsolation,
+  },
+  preview: {
+    headers: crossOriginIsolation,
+  },
+})

--- a/ddk-ts/package.json
+++ b/ddk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bennyblader/ddk-ts",
-  "version": "0.3.42",
+  "version": "0.3.43",
   "description": "dlcdevkit typescript bindings",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -84,8 +84,8 @@
   ],
   "packageManager": "pnpm@10.14.0",
   "optionalDependencies": {
-    "@bennyblader/ddk-ts-darwin-arm64": "0.3.42",
-    "@bennyblader/ddk-ts-linux-x64-gnu": "0.3.42",
-    "@bennyblader/ddk-ts-wasm32-wasi": "0.3.42"
+    "@bennyblader/ddk-ts-darwin-arm64": "0.3.43",
+    "@bennyblader/ddk-ts-linux-x64-gnu": "0.3.43",
+    "@bennyblader/ddk-ts-wasm32-wasi": "0.3.43"
   }
 }

--- a/ddk-ts/package.json
+++ b/ddk-ts/package.json
@@ -4,6 +4,7 @@
   "description": "dlcdevkit typescript bindings",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "browser": "dist/browser.js",
   "type": "module",
   "repository": "https://github.com/bennyhodl/ddk-ffi",
   "license": "MIT",
@@ -38,6 +39,7 @@
     "build": "napi build --platform --release --js index.js --dts index.d.ts --output-dir dist",
     "build:darwin-arm64": "napi build --platform --release --js index.js --dts index.d.ts --output-dir dist --target aarch64-apple-darwin",
     "build:linux-x64": "napi build --platform --release --js index.js --dts index.d.ts --output-dir dist --target x86_64-unknown-linux-gnu",
+    "build:wasm": "napi build --platform --release --js index.js --dts index.d.ts --output-dir dist --target wasm32-wasip1-threads",
     "build:debug": "napi build --platform --js index.js --dts index.d.ts --output-dir dist",
     "build:all": "napi build --release --js index.js --dts index.d.ts --output-dir dist --target aarch64-apple-darwin --target x86_64-unknown-linux-gnu",
     "prepublishOnly": "napi prepublish -t npm",
@@ -83,6 +85,7 @@
   "packageManager": "pnpm@10.14.0",
   "optionalDependencies": {
     "@bennyblader/ddk-ts-darwin-arm64": "0.3.42",
-    "@bennyblader/ddk-ts-linux-x64-gnu": "0.3.42"
+    "@bennyblader/ddk-ts-linux-x64-gnu": "0.3.42",
+    "@bennyblader/ddk-ts-wasm32-wasi": "0.3.42"
   }
 }

--- a/ddk-ts/package.json
+++ b/ddk-ts/package.json
@@ -22,7 +22,8 @@
     "packageName": "@bennyblader/ddk-ts",
     "targets": [
       "aarch64-apple-darwin",
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "wasm32-wasip1-threads"
     ]
   },
   "engines": {
@@ -52,13 +53,15 @@
     "version": "napi version"
   },
   "devDependencies": {
-    "@emnapi/core": "^1.4.5",
-    "@emnapi/runtime": "^1.4.5",
+    "@emnapi/core": "^1.11.2",
+    "@emnapi/runtime": "^1.11.2",
     "@napi-rs/cli": "^3.0.3",
+    "@napi-rs/wasm-runtime": "^1.1.6",
     "@tybys/wasm-util": "^0.10.0",
     "@types/node": "^20.0.0",
     "ava": "^6.4.1",
     "chalk": "^5.4.1",
+    "emnapi": "^1.11.2",
     "lint-staged": "^16.1.2",
     "npm-run-all2": "^8.0.4",
     "prettier": "^3.6.2",

--- a/ddk-ts/pnpm-lock.yaml
+++ b/ddk-ts/pnpm-lock.yaml
@@ -9,14 +9,17 @@ importers:
   .:
     devDependencies:
       '@emnapi/core':
-        specifier: ^1.4.5
-        version: 1.5.0
+        specifier: ^1.11.2
+        version: 1.11.2
       '@emnapi/runtime':
-        specifier: ^1.4.5
-        version: 1.5.0
+        specifier: ^1.11.2
+        version: 1.11.2
       '@napi-rs/cli':
         specifier: ^3.0.3
-        version: 3.2.0(@emnapi/runtime@1.5.0)(@types/node@20.19.13)
+        version: 3.2.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@20.19.13)(emnapi@1.11.2)
+      '@napi-rs/wasm-runtime':
+        specifier: ^1.1.6
+        version: 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       '@tybys/wasm-util':
         specifier: ^0.10.0
         version: 0.10.1
@@ -29,6 +32,9 @@ importers:
       chalk:
         specifier: ^5.4.1
         version: 5.6.2
+      emnapi:
+        specifier: ^1.11.2
+        version: 1.11.2
       lint-staged:
         specifier: ^16.1.2
         version: 16.1.6
@@ -50,6 +56,13 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@20.19.13)(tsx@4.20.5)(yaml@2.8.1)
+    optionalDependencies:
+      '@bennyblader/ddk-ts-darwin-arm64':
+        specifier: 0.3.42
+        version: 0.3.42
+      '@bennyblader/ddk-ts-linux-x64-gnu':
+        specifier: 0.3.42
+        version: 0.3.42
 
   example:
     dependencies:
@@ -69,18 +82,30 @@ importers:
 
 packages:
 
+  '@bennyblader/ddk-ts-darwin-arm64@0.3.42':
+    resolution: {integrity: sha512-6AXhl8UmU42cfSTyu6aSQTwm3EPhJiHjHE0zTWDv+P1aPZiUsNbFZOY81fnz1t5w0KE9t06IaEYY3Mf0Q0ne9Q==}
+    engines: {node: '>= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@bennyblader/ddk-ts-linux-x64-gnu@0.3.42':
+    resolution: {integrity: sha512-Q/ZmjiXj3IWDfI4QXyEha9S6b9ZZ+T4NRDhvaY6ShhixdStT6mR43hkFw+5WRWxoWMT2HALjkct54L3VyWUjig==}
+    engines: {node: '>= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@emnapi/core@1.5.0':
-    resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
 
-  '@emnapi/runtime@1.5.0':
-    resolution: {integrity: sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==}
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
-  '@emnapi/wasi-threads@1.1.0':
-    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.25.9':
     resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
@@ -643,8 +668,11 @@ packages:
     resolution: {integrity: sha512-7cmzIu+Vbupriudo7UudoMRH2OA3cTw67vva8MxeoAe5S7vPFI7z0vp0pMXiA25S8IUJefImQ90FeJjl8fjEaQ==}
     engines: {node: '>= 10'}
 
-  '@napi-rs/wasm-runtime@1.0.4':
-    resolution: {integrity: sha512-+ZEtJPp8EF8h4kN6rLQECRor00H7jtDgBVtttIUoxuDkXLiQMaSBqju3LV/IEsMvqVG5pviUvR4jYhIA1xNm8w==}
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
     resolution: {integrity: sha512-lr07E/l571Gft5v4aA1dI8koJEmF1F0UigBbsqg9OWNzg80H3lDPO+auv85y3T/NHE3GirDk7x/D3sLO57vayw==}
@@ -927,6 +955,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -1215,6 +1246,14 @@ packages:
     resolution: {integrity: sha512-KxdRyyFcS85pH3dnU8Y5yFUm2YJdaHwcBZWrfG8o89ZY9a13/f9itbN+YG3ELbBo9Pg5zvIozstmuV8bX13q6g==}
     engines: {node: '>=14.16'}
 
+  emnapi@1.11.2:
+    resolution: {integrity: sha512-iMt/XQc69fFn2EvcU6tm14HmXKwyy0lnABugsQlqp6xFuZIUuO+ONVSg2mz+MTVF8WbC+bic65AvRXdoldALKg==}
+    peerDependencies:
+      node-addon-api: '>= 6.1.0'
+    peerDependenciesMeta:
+      node-addon-api:
+        optional: true
+
   emoji-regex@10.5.0:
     resolution: {integrity: sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==}
 
@@ -1340,6 +1379,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globby@14.1.0:
@@ -1791,6 +1831,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp-dir@3.0.0:
     resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
@@ -2041,20 +2082,26 @@ packages:
 
 snapshots:
 
+  '@bennyblader/ddk-ts-darwin-arm64@0.3.42':
+    optional: true
+
+  '@bennyblader/ddk-ts-linux-x64-gnu@0.3.42':
+    optional: true
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@emnapi/core@1.5.0':
+  '@emnapi/core@1.11.2':
     dependencies:
-      '@emnapi/wasi-threads': 1.1.0
+      '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
 
-  '@emnapi/runtime@1.5.0':
+  '@emnapi/runtime@1.11.2':
     dependencies:
       tslib: 2.8.1
 
-  '@emnapi/wasi-threads@1.1.0':
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
 
@@ -2294,11 +2341,11 @@ snapshots:
       - encoding
       - supports-color
 
-  '@napi-rs/cli@3.2.0(@emnapi/runtime@1.5.0)(@types/node@20.19.13)':
+  '@napi-rs/cli@3.2.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@20.19.13)(emnapi@1.11.2)':
     dependencies:
       '@inquirer/prompts': 7.8.4(@types/node@20.19.13)
-      '@napi-rs/cross-toolchain': 1.0.3
-      '@napi-rs/wasm-tools': 1.0.1
+      '@napi-rs/cross-toolchain': 1.0.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-tools': 1.0.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       '@octokit/rest': 22.0.0
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       colorette: 2.0.20
@@ -2309,8 +2356,10 @@ snapshots:
       semver: 7.7.2
       typanion: 3.14.0
     optionalDependencies:
-      '@emnapi/runtime': 1.5.0
+      '@emnapi/runtime': 1.11.2
+      emnapi: 1.11.2
     transitivePeerDependencies:
+      - '@emnapi/core'
       - '@napi-rs/cross-toolchain-arm64-target-aarch64'
       - '@napi-rs/cross-toolchain-arm64-target-armv7'
       - '@napi-rs/cross-toolchain-arm64-target-ppc64le'
@@ -2324,12 +2373,14 @@ snapshots:
       - '@types/node'
       - supports-color
 
-  '@napi-rs/cross-toolchain@1.0.3':
+  '@napi-rs/cross-toolchain@1.0.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@napi-rs/lzma': 1.4.5
-      '@napi-rs/tar': 1.1.0
+      '@napi-rs/lzma': 1.4.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@napi-rs/tar': 1.1.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       debug: 4.4.1
     transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
       - supports-color
 
   '@napi-rs/lzma-android-arm-eabi@1.4.5':
@@ -2371,9 +2422,12 @@ snapshots:
   '@napi-rs/lzma-linux-x64-musl@1.4.5':
     optional: true
 
-  '@napi-rs/lzma-wasm32-wasi@1.4.5':
+  '@napi-rs/lzma-wasm32-wasi@1.4.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.4
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
   '@napi-rs/lzma-win32-arm64-msvc@1.4.5':
@@ -2385,7 +2439,7 @@ snapshots:
   '@napi-rs/lzma-win32-x64-msvc@1.4.5':
     optional: true
 
-  '@napi-rs/lzma@1.4.5':
+  '@napi-rs/lzma@1.4.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     optionalDependencies:
       '@napi-rs/lzma-android-arm-eabi': 1.4.5
       '@napi-rs/lzma-android-arm64': 1.4.5
@@ -2400,10 +2454,13 @@ snapshots:
       '@napi-rs/lzma-linux-s390x-gnu': 1.4.5
       '@napi-rs/lzma-linux-x64-gnu': 1.4.5
       '@napi-rs/lzma-linux-x64-musl': 1.4.5
-      '@napi-rs/lzma-wasm32-wasi': 1.4.5
+      '@napi-rs/lzma-wasm32-wasi': 1.4.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       '@napi-rs/lzma-win32-arm64-msvc': 1.4.5
       '@napi-rs/lzma-win32-ia32-msvc': 1.4.5
       '@napi-rs/lzma-win32-x64-msvc': 1.4.5
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   '@napi-rs/tar-android-arm-eabi@1.1.0':
     optional: true
@@ -2441,9 +2498,12 @@ snapshots:
   '@napi-rs/tar-linux-x64-musl@1.1.0':
     optional: true
 
-  '@napi-rs/tar-wasm32-wasi@1.1.0':
+  '@napi-rs/tar-wasm32-wasi@1.1.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.4
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
   '@napi-rs/tar-win32-arm64-msvc@1.1.0':
@@ -2455,7 +2515,7 @@ snapshots:
   '@napi-rs/tar-win32-x64-msvc@1.1.0':
     optional: true
 
-  '@napi-rs/tar@1.1.0':
+  '@napi-rs/tar@1.1.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     optionalDependencies:
       '@napi-rs/tar-android-arm-eabi': 1.1.0
       '@napi-rs/tar-android-arm64': 1.1.0
@@ -2469,17 +2529,19 @@ snapshots:
       '@napi-rs/tar-linux-s390x-gnu': 1.1.0
       '@napi-rs/tar-linux-x64-gnu': 1.1.0
       '@napi-rs/tar-linux-x64-musl': 1.1.0
-      '@napi-rs/tar-wasm32-wasi': 1.1.0
+      '@napi-rs/tar-wasm32-wasi': 1.1.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       '@napi-rs/tar-win32-arm64-msvc': 1.1.0
       '@napi-rs/tar-win32-ia32-msvc': 1.1.0
       '@napi-rs/tar-win32-x64-msvc': 1.1.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
-  '@napi-rs/wasm-runtime@1.0.4':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@emnapi/core': 1.5.0
-      '@emnapi/runtime': 1.5.0
-      '@tybys/wasm-util': 0.10.1
-    optional: true
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
 
   '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
     optional: true
@@ -2508,9 +2570,12 @@ snapshots:
   '@napi-rs/wasm-tools-linux-x64-musl@1.0.1':
     optional: true
 
-  '@napi-rs/wasm-tools-wasm32-wasi@1.0.1':
+  '@napi-rs/wasm-tools-wasm32-wasi@1.0.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.4
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
   '@napi-rs/wasm-tools-win32-arm64-msvc@1.0.1':
@@ -2522,7 +2587,7 @@ snapshots:
   '@napi-rs/wasm-tools-win32-x64-msvc@1.0.1':
     optional: true
 
-  '@napi-rs/wasm-tools@1.0.1':
+  '@napi-rs/wasm-tools@1.0.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     optionalDependencies:
       '@napi-rs/wasm-tools-android-arm-eabi': 1.0.1
       '@napi-rs/wasm-tools-android-arm64': 1.0.1
@@ -2533,10 +2598,13 @@ snapshots:
       '@napi-rs/wasm-tools-linux-arm64-musl': 1.0.1
       '@napi-rs/wasm-tools-linux-x64-gnu': 1.0.1
       '@napi-rs/wasm-tools-linux-x64-musl': 1.0.1
-      '@napi-rs/wasm-tools-wasm32-wasi': 1.0.1
+      '@napi-rs/wasm-tools-wasm32-wasi': 1.0.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       '@napi-rs/wasm-tools-win32-arm64-msvc': 1.0.1
       '@napi-rs/wasm-tools-win32-ia32-msvc': 1.0.1
       '@napi-rs/wasm-tools-win32-x64-msvc': 1.0.1
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -2697,6 +2765,10 @@ snapshots:
   '@tsconfig/node16@1.0.4': {}
 
   '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
 
@@ -2999,6 +3071,8 @@ snapshots:
   eastasianwidth@0.2.0: {}
 
   emittery@1.2.0: {}
+
+  emnapi@1.11.2: {}
 
   emoji-regex@10.5.0: {}
 

--- a/ddk-ts/pnpm-lock.yaml
+++ b/ddk-ts/pnpm-lock.yaml
@@ -80,6 +80,19 @@ importers:
         specifier: ^5.0.0
         version: 5.9.2
 
+  example-browser:
+    dependencies:
+      '@bennyblader/ddk-ts':
+        specifier: workspace:*
+        version: link:..
+    devDependencies:
+      '@napi-rs/wasm-runtime':
+        specifier: ^1.1.6
+        version: 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      vite:
+        specifier: ^5.4.0
+        version: 5.4.21(@types/node@20.19.13)
+
 packages:
 
   '@bennyblader/ddk-ts-darwin-arm64@0.3.42':
@@ -107,16 +120,34 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.9':
     resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.9':
     resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.9':
@@ -125,16 +156,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.9':
     resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.9':
     resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.9':
@@ -143,10 +192,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.9':
     resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.9':
@@ -155,10 +216,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.9':
     resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.9':
@@ -167,10 +240,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.9':
     resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.9':
@@ -179,10 +264,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.9':
     resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.9':
@@ -191,16 +288,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.9':
     resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.9':
     resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.9':
@@ -215,6 +330,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.9':
     resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
     engines: {node: '>=18'}
@@ -225,6 +346,12 @@ packages:
     resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.9':
@@ -239,11 +366,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.9':
     resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.9':
     resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
@@ -251,10 +390,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.9':
     resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.9':
@@ -1273,6 +1424,11 @@ packages:
   es-toolkit@1.39.10:
     resolution: {integrity: sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==}
 
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.25.9:
     resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
     engines: {node: '>=18'}
@@ -1934,6 +2090,37 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
   vite@7.1.5:
     resolution: {integrity: sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2105,52 +2292,103 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.9':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.9':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.9':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.9':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.9':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.9':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.9':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.9':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.9':
@@ -2159,10 +2397,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.25.9':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.9':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.9':
@@ -2171,13 +2415,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.9':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.9':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.9':
@@ -3086,6 +3342,32 @@ snapshots:
 
   es-toolkit@1.39.10: {}
 
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
   esbuild@0.25.9:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.9
@@ -3684,16 +3966,15 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
-  vite-node@3.2.4(@types/node@20.19.13)(tsx@4.20.5)(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@20.19.13):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.5(@types/node@20.19.13)(tsx@4.20.5)(yaml@2.8.1)
+      vite: 5.4.21(@types/node@20.19.13)
     transitivePeerDependencies:
       - '@types/node'
-      - jiti
       - less
       - lightningcss
       - sass
@@ -3702,8 +3983,15 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-      - tsx
-      - yaml
+
+  vite@5.4.21(@types/node@20.19.13):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.50.1
+    optionalDependencies:
+      '@types/node': 20.19.13
+      fsevents: 2.3.3
 
   vite@7.1.5(@types/node@20.19.13)(tsx@4.20.5)(yaml@2.8.1):
     dependencies:
@@ -3742,7 +4030,7 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.1.5(@types/node@20.19.13)(tsx@4.20.5)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@20.19.13)(tsx@4.20.5)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@20.19.13)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.13

--- a/ddk-ts/pnpm-workspace.yaml
+++ b/ddk-ts/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "."
   - "example"
+  - "example-browser"


### PR DESCRIPTION
## What

Adds a `wasm32-wasip1-threads` build target to ddk-ts so the bindings run in browsers.

- Add `wasm32-wasip1-threads` to `napi.targets`
- Drop the unused napi `async` feature from `ddk-ts/Cargo.toml` — there are no async bindings, and it pulls in tokio plus an `_emnapi_async_worker` wasm import that breaks instantiation
- Add `emnapi` + `@napi-rs/wasm-runtime` devDeps required by the wasi build (and bump `@emnapi/core`/`@emnapi/runtime` — older versions mismatch the build-time emnapi and fail with a LinkError on `_emnapi_async_worker`)

## Build

```bash
rustup target add wasm32-wasip1-threads
# wasi-sdk needed for the secp256k1-zkp C code
WASI_SDK_PATH=~/wasi-sdk-33 pnpm napi build --platform --release \
  --js index.js --dts index.d.ts --output-dir dist --target wasm32-wasip1-threads
```

Produces `ddk-ts.wasm32-wasi.wasm` (~3.5MB) plus the napi-generated Node (`ddk-ts.wasi.cjs`) and browser (`ddk-ts.wasi-browser.js` + worker) loaders. Native builds are unaffected.

## Verified

- All 15 vitest tests pass under `NAPI_RS_FORCE_WASI=1` (wasm binding in Node)
- Native darwin-arm64 build + tests still pass with the `async` feature removed
- In-browser: full DLC flow (createDlcTransactions, adaptor sigs, signCet) running client-side in Chrome for the btc++ Toronto workshop, settling real contracts on testnet4 — e.g. fund [76c34058…](https://mempool.space/testnet4/tx/76c3405846bf79d116745810334b585535818ebe706be0544c86fb99575480b3) / CET [b4cf7340…](https://mempool.space/testnet4/tx/b4cf7340121a657597d5cbb73e7e8252006f5c57fdeabacc1a2ba9639635a9a3)

Browser use needs cross-origin isolation (COOP/COEP headers) for SharedArrayBuffer since the threads target uses shared wasm memory.

Follow-up (happy to do either here or separately): add the target to CI and publish `@bennyblader/ddk-ts-wasm32-wasi` so consumers don't need to vendor the artifact.